### PR TITLE
chrome.storage.localへの変更

### DIFF
--- a/options.js
+++ b/options.js
@@ -4,14 +4,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const input = document.getElementById('apiKeyInput');
 
   // Load existing API key
-  chrome.storage.sync.get(['geminiApiKey'], (items) => {
+  chrome.storage.local.get(['geminiApiKey'], (items) => {
     if (items.geminiApiKey) {
       input.value = items.geminiApiKey;
     }
   });
 
   document.getElementById('saveButton').addEventListener('click', () => {
-    chrome.storage.sync.set({ geminiApiKey: input.value }, () => {
+    chrome.storage.local.set({ geminiApiKey: input.value }, () => {
       alert('保存しました');
     });
   });

--- a/popup.js
+++ b/popup.js
@@ -81,7 +81,7 @@ function calculateCharacterCount(text) {
 // chrome.storage から API キー取得
 function loadApiKey() {
   return new Promise((resolve) => {
-    chrome.storage.sync.get(["geminiApiKey"], (items) => {
+    chrome.storage.local.get(["geminiApiKey"], (items) => {
       resolve(items.geminiApiKey || "");
     });
   });


### PR DESCRIPTION
## 概要
options.js と popup.js で `chrome.storage.sync` を `chrome.storage.local` に置き換えました。これにより API キーをローカルストレージに保存するようになります。

## テスト
- `npm test` を実行しましたが、テストスクリプトが定義されていないためエラーになりました。


------
https://chatgpt.com/codex/tasks/task_e_68476d8b5ae48333a40761d0c6376fe7