### PR TITLE
manifest.json のホストパーミッション追加

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
   "name": "kirara-to-x-poster",
   "version": "1.0",
   "permissions": ["activeTab", "scripting", "storage"],
+  "host_permissions": ["https://generativelanguage.googleapis.com/*"],
   "action": {
     "default_popup": "popup.html"
   },


### PR DESCRIPTION
## 概要

`manifest.json` に Google Generative Language API を使用するための `host_permissions` を追加しました。

## テスト結果

- `npm test` を実行しましたが、テストは用意されていないためエラー終了しました。


------
https://chatgpt.com/codex/tasks/task_e_68476fad60288333940b316ff0bc9f68