### PR TITLE
ボタンのレイアウトを flex 化

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -52,8 +52,13 @@ p {
   color: #555;
 }
 
+.button-row {
+  display: flex;
+  gap: 10px;
+}
+
 button {
-  width: 50%;
+  flex: 1;
   padding: 10px;
   font-size: 1.1em;
   color: white;

--- a/popup.html
+++ b/popup.html
@@ -13,8 +13,10 @@
             <h1>KIRARAからXへ投稿</h1>
             <textarea id="output" rows="10" cols="50" placeholder="内容がここに表示されます..."></textarea>
             <p id="charCount">文字数: 0</p>
-            <button id="summarize">Geminiで要約</button>
-            <button id="postToX">Xへ投稿</button>
+            <div class="button-row">
+                <button id="summarize">Geminiで要約</button>
+                <button id="postToX">Xへ投稿</button>
+            </div>
             <p><a href="options.html" target="_blank">オプション</a></p>
         </div>
 


### PR DESCRIPTION
## 変更点
- `popup.html` の二つのボタンを `<div class="button-row">` で囲みました
- `popup.css` に `.button-row { display: flex; gap: 10px; }` を追加
- ボタンの `width` 指定を `flex: 1;` に変更し、横幅を均等化

## テスト
- テストスクリプトは提供されていないため実行なし

------
https://chatgpt.com/codex/tasks/task_e_684786381bb88333a3bee16aef78ea62