### PR TITLE
オプションページのCSS追加

### DIFF
--- a/options.css
+++ b/options.css
@@ -1,0 +1,92 @@
+/* オプションページ用スタイル */
+body {
+  font-family: 'Arial', sans-serif;
+  font-size: 16px;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  width: 600px;
+  background-color: #f0f0f0;
+}
+
+.container {
+  width: 90%;
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5em;
+  text-align: center;
+  color: #333;
+  margin-bottom: 15px;
+}
+
+input {
+  width: 80%;
+  padding: 10px;
+  border-radius: 5px;
+  border: 1px solid #ccc;
+  font-size: 1em;
+}
+
+input:focus {
+  border-color: #007bff;
+  outline: none;
+}
+
+button {
+  width: 50%;
+  padding: 10px;
+  margin-top: 10px;
+  font-size: 1.1em;
+  color: white;
+  background-color: #007bff;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+button:hover {
+  background-color: #0056b3;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #121212;
+  }
+
+  .container {
+    background-color: #1e1e1e;
+    box-shadow: 0px 4px 10px rgba(255, 255, 255, 0.1);
+  }
+
+  h1 {
+    color: #ddd;
+  }
+
+  input {
+    background-color: #333;
+    color: #ddd;
+    border-color: #555;
+  }
+
+  input:focus {
+    border-color: #66bfff;
+  }
+
+  button {
+    background-color: #0056b3;
+  }
+
+  button:hover {
+    background-color: #004494;
+  }
+}

--- a/options.html
+++ b/options.html
@@ -3,11 +3,14 @@
 <head>
   <meta charset="UTF-8">
   <title>オプション</title>
+  <link rel="stylesheet" href="options.css">
 </head>
 <body>
-  <h1>Gemini APIキー設定</h1>
-  <input type="password" id="apiKeyInput" placeholder="APIキー" />
-  <button id="saveButton">保存</button>
+  <div class="container">
+    <h1>Gemini APIキー設定</h1>
+    <input type="password" id="apiKeyInput" placeholder="APIキー" />
+    <button id="saveButton">保存</button>
+  </div>
   <script src="options.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## 概要
- `options.css` を新規作成し、`popup.css` と同じスタイルを適用
- `options.html` に CSS を読み込み、要素を `.container` でラップ

## テスト
- `npm test` を実行し、テスト未実装のメッセージを確認
- `npm run build` を試みたが `browserify` が無く失敗


------
https://chatgpt.com/codex/tasks/task_e_6847864b2a508333b62e8f5aa9048ec3