### PR TITLE
Gemini要約時のローディング表示追加

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -13,6 +13,7 @@ body {
 }
 
 .container {
+  position: relative;
   width: 90%;
   /* max-width: 500px; */
   background-color: #fff;
@@ -73,12 +74,12 @@ button:hover {
   background-color: #0056b3;
 }
 
-/* ボタンの無効化スタイル
+/* ボタンの無効化スタイル */
 button:disabled {
   background-color: #ccc;
   cursor: not-allowed;
   opacity: 0.6;
-} */
+}
 
 
 /* ダークモード対応 */
@@ -117,4 +118,42 @@ button:disabled {
   button:hover {
       background-color: #004494;
   }
+}
+
+/* ローディングオーバーレイ */
+#loadingOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.7);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+}
+
+#loadingOverlay.active {
+  display: flex;
+}
+
+.spinner {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #3498db;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+}
+
+@media (prefers-color-scheme: dark) {
+  #loadingOverlay {
+    background: rgba(0, 0, 0, 0.7);
+  }
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
 }

--- a/popup.html
+++ b/popup.html
@@ -18,6 +18,7 @@
                 <button id="postToX">Xへ投稿</button>
             </div>
             <p><a href="options.html" target="_blank">オプション</a></p>
+            <div id="loadingOverlay"><div class="spinner"></div></div>
         </div>
 
         <script src="dist/twitter-text-bundle.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -4,6 +4,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const charCountElement = document.getElementById("charCount");
   const postButton = document.getElementById("postToX");
   const summarizeButton = document.getElementById("summarize");
+  const loadingOverlay = document.getElementById("loadingOverlay");
 
   // 背景ページから取得した元テキストを保持
   let originalText = "";
@@ -29,6 +30,8 @@ document.addEventListener("DOMContentLoaded", () => {
       alert("APIキーが未設定です");
       return;
     }
+    loadingOverlay.classList.add("active");
+    summarizeButton.disabled = true;
     try {
       const summary = await summarizeWithGemini(originalText, apiKey);
       outputTextarea.value = summary;
@@ -36,6 +39,9 @@ document.addEventListener("DOMContentLoaded", () => {
     } catch (e) {
       console.error("Gemini summarization failed", e);
       alert("要約に失敗しました");
+    } finally {
+      loadingOverlay.classList.remove("active");
+      summarizeButton.disabled = false;
     }
   });
 


### PR DESCRIPTION
## 概要
- 要約ボタン押下時にローディングスピナーを表示
- 処理中はボタンを無効化
- CSS にオーバーレイとスピナーのスタイルを追加

## テスト結果
- `npm test` 実行結果:
```
Error: no test specified
```


------
https://chatgpt.com/codex/tasks/task_e_6847b20c423c83338993e5140b3cb0dd