### PR TITLE
エラーハンドリング追加

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,14 +1,30 @@
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "runModal") {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      if (chrome.runtime.lastError) {
+        console.error("tabs.query failed", chrome.runtime.lastError);
+        sendResponse({ error: chrome.runtime.lastError.message });
+        return;
+      }
+      if (!tabs[0]) {
+        sendResponse({ error: "No active tab found" });
+        return;
+      }
       chrome.scripting.executeScript(
         {
           target: { tabId: tabs[0].id },
           func: runModal,
         },
         (results) => {
+          if (chrome.runtime.lastError) {
+            console.error("executeScript failed", chrome.runtime.lastError);
+            sendResponse({ error: chrome.runtime.lastError.message });
+            return;
+          }
           if (results && results[0]) {
             sendResponse(results[0].result);
+          } else {
+            sendResponse({ error: "No result" });
           }
         }
       );

--- a/options.js
+++ b/options.js
@@ -5,6 +5,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Load existing API key
   chrome.storage.local.get(['geminiApiKey'], (items) => {
+    if (chrome.runtime.lastError) {
+      console.error('APIキーの読み込みに失敗しました', chrome.runtime.lastError);
+      return;
+    }
     if (items.geminiApiKey) {
       input.value = items.geminiApiKey;
     }
@@ -12,7 +16,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.getElementById('saveButton').addEventListener('click', () => {
     chrome.storage.local.set({ geminiApiKey: input.value }, () => {
-      alert('保存しました');
+      if (chrome.runtime.lastError) {
+        console.error('APIキーの保存に失敗しました', chrome.runtime.lastError);
+        alert('保存に失敗しました');
+      } else {
+        alert('保存しました');
+      }
     });
   });
 });

--- a/popup.js
+++ b/popup.js
@@ -17,6 +17,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // バックグラウンドからデータ取得
   chrome.runtime.sendMessage({ action: "runModal" }, (response) => {
+    if (chrome.runtime.lastError) {
+      console.error("メッセージ送信に失敗しました", chrome.runtime.lastError);
+      return;
+    }
     if (response) {
       outputTextarea.value = response.output;
       originalText = response.output;
@@ -48,12 +52,19 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // オプション表示ボタン
   openOptionsBtn.addEventListener("click", () => {
-    chrome.windows.create({
-      url: chrome.runtime.getURL("options.html"),
-      type: "popup",
-      width: 400,
-      height: 200,
-    });
+    chrome.windows.create(
+      {
+        url: chrome.runtime.getURL("options.html"),
+        type: "popup",
+        width: 400,
+        height: 200,
+      },
+      () => {
+        if (chrome.runtime.lastError) {
+          console.error("オプションウィンドウの表示に失敗しました", chrome.runtime.lastError);
+        }
+      }
+    );
   });
 
 
@@ -104,9 +115,19 @@ function calculateCharacterCount(text) {
 // chrome.storage から API キー取得
 function loadApiKey() {
   return new Promise((resolve) => {
-    chrome.storage.local.get(["geminiApiKey"], (items) => {
-      resolve(items.geminiApiKey || "");
-    });
+    try {
+      chrome.storage.local.get(["geminiApiKey"], (items) => {
+        if (chrome.runtime.lastError) {
+          console.error("APIキー取得に失敗しました", chrome.runtime.lastError);
+          resolve("");
+        } else {
+          resolve(items.geminiApiKey || "");
+        }
+      });
+    } catch (e) {
+      console.error("APIキー取得時に例外", e);
+      resolve("");
+    }
   });
 }
 
@@ -124,20 +145,32 @@ async function summarizeWithGemini(text, apiKey) {
     ],
   };
 
-  const res = await fetch(
-    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    }
-  );
+  let res;
+  try {
+    res = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }
+    );
+  } catch (e) {
+    console.error("APIリクエストに失敗しました", e);
+    throw e;
+  }
 
   if (!res.ok) {
     throw new Error("API request failed");
   }
 
-  const data = await res.json();
+  let data;
+  try {
+    data = await res.json();
+  } catch (e) {
+    console.error("レスポンスの解析に失敗しました", e);
+    throw e;
+  }
   return (
     data.candidates?.[0]?.content?.parts?.[0]?.text || text
   );


### PR DESCRIPTION
## 概要
- オプションページでの API キー保存/読込時に `chrome.runtime.lastError` を確認
- ポップアップでのメッセージ送信、API キー読込、Gemini API 呼び出しなどに例外処理を追加
- バックグラウンドで `chrome.tabs.query` と `executeScript` 実行時の失敗を捕捉

## テスト
- `npm test` 実行（失敗を確認）
- `npm run build` 実行（browserify 未インストールのため失敗）

------
https://chatgpt.com/codex/tasks/task_e_68481d23c7388333a63b244ce116dde2