### PR TITLE
ダークモード文字色調整

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -88,7 +88,11 @@ function updateCharacterCount(textarea, countElement) {
   const isOver = count > 280;
 
   countElement.textContent = `文字数: ${count}/280`;
-  countElement.style.color = isOver ? "#ff0000" : "#000000";
+
+  const isDark = window.matchMedia &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const normalColor = isDark ? '#dddddd' : '#000000';
+  countElement.style.color = isOver ? '#ff0000' : normalColor;
 }
 
 // twitter-textライブラリを使用した正確な文字カウントロジック


### PR DESCRIPTION
## 概要
* `popup.js` の文字数カウント表示色をダークモードでも見やすいように調整しました。

## テスト結果
- `npm test` はテストスクリプトが存在しないためエラー終了しました。


------
https://chatgpt.com/codex/tasks/task_e_684a4a6caec88333aba6c02e8735a4c2