### PR TITLE
拡張機能の有効化条件を追加

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,17 @@
+const KIRARA_URL_PREFIX =
+  "https://kirara-code.net/HappinessChain/reports/";
+
+// タブのURL変更時に拡張機能の有効/無効を切り替える
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status === "complete" && tab.url) {
+    if (tab.url.startsWith(KIRARA_URL_PREFIX)) {
+      chrome.action.enable(tabId);
+    } else {
+      chrome.action.disable(tabId);
+    }
+  }
+});
+
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "runModal") {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "kirara-to-x-poster",
   "version": "1.0",
-  "permissions": ["activeTab", "scripting", "storage"],
+  "permissions": ["activeTab", "scripting", "storage", "tabs"],
   "host_permissions": ["https://generativelanguage.googleapis.com/*"],
   "action": {
     "default_popup": "popup.html"


### PR DESCRIPTION
## 変更点
- `background.js` にタブ更新時のURLチェック処理を追加し、`https://kirara-code.net/HappinessChain/reports/` 配下でのみアイコンを有効化
- `manifest.json` に `tabs` パーミッションを追加

## テスト
- `npm test` を実行し、テストが未定義であることを確認

------
https://chatgpt.com/codex/tasks/task_e_684a4eebce648333a7885aef35a4d7b7